### PR TITLE
Added the functionality to fetch the glossary term by term id or term name

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,29 +7,30 @@ import config
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-try:
-    # Get authentication token
-    logging.info("Attempting to get Purview token...")
-    token = get_purview_token(config.tenant_id, config.client_id, config.client_secret, config.resource)
-    logging.info("Successfully obtained Purview token.")
+# try:
+# Get authentication token
+logging.info("Attempting to get Purview token...")
+token = get_purview_token(config.tenant_id, config.client_id, config.client_secret, config.resource)
+logging.info("Successfully obtained Purview token.")
 
-    # Set up headers with the token
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json"
-    }
+# Set up headers with the token
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Content-Type": "application/json"
+}
 
-    # Initialize glossary manager
-    logging.info("Initializing PurviewGlossaryManager...")
-    glossary_manager = PurviewGlossaryManager(token, config.tenant_id, headers)
-    logging.info("PurviewGlossaryManager initialized successfully.")
+# Initialize glossary manager
+logging.info("Initializing PurviewGlossaryManager...")
+glossary_manager = PurviewGlossaryManager(token, config.tenant_id, headers)
+logging.info("PurviewGlossaryManager initialized successfully.")
 
-    # Read glossary terms from Excel
-    logging.info("Reading glossary terms from Excel...")
-    glossary_terms = read_glossary_terms_from_excel('Enterprise-Glossary-Terms.xlsx')
-    logging.info(f"Successfully read {len(glossary_terms)} glossary terms from Excel.")
+# Read glossary terms from Excel
+logging.info("Reading glossary terms from Excel...")
+glossary_terms = read_glossary_terms_from_excel('Enterprise-Glossary-Terms.xlsx')
+logging.info(f"Successfully read {len(glossary_terms)} glossary terms from Excel.")
 
-    glossary_manager.upload_glossary_terms(glossary_terms)
+print(glossary_manager.get_term(term_id="4bf2fe0e-4768-40ba-b8d6-f5837c486e6f"))
+# print(glossary_manager.get_term(term_name="Accounts Payable (AP)"))
 
-except Exception as e:
-    logging.error(f"An error occurred: {str(e)}")
+# except Exception as e:
+#     logging.error(f"An error occurred: {str(e)}")


### PR DESCRIPTION
"""
Fetches a glossary term from Microsoft Purview based on either term ID or term name.

Args:
    term_id (str, optional): The unique identifier (GUID) of the glossary term.
    term_name (str, optional): The name of the glossary term.

Returns:
    dict or list: If fetching by term_id, returns a dictionary with the term's details. 
                If fetching by term_name, returns a list of terms that match the name.

Raises:
    Exception: 
        - If both term_id and term_name are provided (only one should be used at a time).
        - If neither term_id nor term_name is provided.
        - If there is a permission issue (403 error) when fetching by term_id.
        - If no glossary term is found with the provided term_name.

Notes:
    - If term_id is provided, it directly queries the API using the term's unique ID.
    - If term_name is provided, it searches the list of all glossary terms and returns matches.
    - Requires appropriate permissions to fetch terms (ensure the user has Data Steward Role).
"""